### PR TITLE
Safe wg usage

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -33,8 +33,8 @@ func main() {
 	stop := make(chan os.Signal)
 	signal.Notify(stop, syscall.SIGINT)
 	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 		server.Serve(sl)
 	}()


### PR DESCRIPTION
wait groups should be incremented outside of the go routine in situations like this, or else you get in a race condition.  